### PR TITLE
prevent notice, add more data

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Field Options
 Change Log
 ----------
 
+- 1.6
+  - Added support for category description, category order, category parent ID, category group ID, and category site ID
+  - Prevent PHP notice when category select has no value
 - 1.5
   - Added support for category image
   - Removed old backspace code in lieu of built-in backspace support

--- a/README.md
+++ b/README.md
@@ -28,8 +28,14 @@ You can also use a variable pair:
 You have access to several variables inside the variable pair:
 
 - `{category_id}`
+- `{category_site_id}`
+- `{category_group_id}`
+- `{category_parent_id}`
 - `{category_name}`
 - `{category_url_title}`
+- `{category_description}`
+- `{category_image}`
+- `{category_order}`
 
 You also have access to one parameter:
 

--- a/third_party/wb_category_select/config.php
+++ b/third_party/wb_category_select/config.php
@@ -3,7 +3,7 @@
 if (! defined('WB_CAT_SELECT_NAME'))
 {
 	define('WB_CAT_SELECT_NAME', 'WB Category Select');
-	define('WB_CAT_SELECT_VER',  '1.5');
+	define('WB_CAT_SELECT_VER',  '1.6');
 }
 
 $config['name']    = WB_CAT_SELECT_NAME;

--- a/third_party/wb_category_select/ft.wb_category_select.php
+++ b/third_party/wb_category_select/ft.wb_category_select.php
@@ -375,7 +375,7 @@ class Wb_category_select_ft extends EE_Fieldtype {
 				$process = array();
 				foreach ($category_data[$category_id] as $k => $v)
 				{
-					$k = false !== strpos($k,'cat_') ? str_replace('cat_','category_',$k) : 'category_'.$k;
+					$k = (strpos($k,'cat_') !== false) ? str_replace('cat_','category_',$k) : 'category_'.$k;
 					$process[$k] = $v;
 				}
 

--- a/third_party/wb_category_select/ft.wb_category_select.php
+++ b/third_party/wb_category_select/ft.wb_category_select.php
@@ -370,12 +370,17 @@ class Wb_category_select_ft extends EE_Fieldtype {
 		$parse = array();
 		foreach ($cat_ids as $category_id)
 		{
-			$parse[] = array(
-				'category_id'        => $category_id,
-				'category_name'      => $category_data[$category_id]['cat_name'],
-				'category_url_title' => $category_data[$category_id]['cat_url_title'],
-				'category_image'     => $category_data[$category_id]['cat_image']
-			);
+			if( isset( $category_data[$category_id] ) )
+			{
+				$process = array();
+				foreach ($category_data[$category_id] as $k => $v)
+				{
+					$k = false !== strpos($k,'cat_') ? str_replace('cat_','category_',$k) : 'category_'.$k;
+					$process[$k] = $v;
+				}
+
+				$parse[] = $process;
+			}
 		}
 
 		return $parse;


### PR DESCRIPTION
Check if `$category_data[$category_id]` is set, and add all available data to the array (e.g. category description). Tested with PHP 5.2.x.

Example output:

```
array (size=1)
  0 => 
    array (size=9)
      'category_id' => string '19' (length=2)
      'category_site_id' => string '1' (length=1)
      'category_group_id' => string '3' (length=1)
      'category_parent_id' => string '0' (length=1)
      'category_name' => string 'Bulldog' (length=9)
      'category_url_title' => string 'bulldog' (length=9)
      'category_description' => string 'The Bulldog is a medium-sized breed of dog commonly referred to as the English Bulldog or British Bulldog.' (length=106)
      'category_image' => string '{filedir_1}bulldog.jpg' (length=35)
      'category_order' => string '4' (length=1)
```